### PR TITLE
Update file_util.py

### DIFF
--- a/kiauto/file_util.py
+++ b/kiauto/file_util.py
@@ -26,7 +26,7 @@ from kiauto import log
 logger = log.get_logger(__name__)
 
 
-def wait_for_file_created_by_process(pid, file, timeout=15):
+def wait_for_file_created_by_process(pid, file, timeout=150):
     process = psutil.Process(pid)
 
     DELAY = 0.2


### PR DESCRIPTION
Since the timeout is not settled by eeschema_do regardless you type in with  --wait_start   or   --time_out_scale  I need to increase this number in my virtual machine (LUbuntu 20.10) as a kind of quick & dirty BUG fix.

I work with Oracle Virtual Box and write to my Windows based file system via shared folder feature of VirtualBox.  Therefore you need time to write and read back ;-)

Best would be to put the --time_out_scale in cfg-Array ? Did not really go too much into the depth of this code ..sorry.